### PR TITLE
CLOUD-494: Trim administer-resource actions

### DIFF
--- a/k9policy/k9-access_capability.administer-resource.tsv
+++ b/k9policy/k9-access_capability.administer-resource.tsv
@@ -10,8 +10,6 @@ kms:DisableKey
 kms:DisableKeyRotation
 kms:EnableKey
 kms:EnableKeyRotation
-kms:GetKeyRotationStatus
-kms:GetKeyPolicy
 kms:PutKeyPolicy
 kms:RetireGrant
 kms:RevokeGrant


### PR DESCRIPTION
Remove GetKeyPolicy & GetKeyRotationStatus from administer-resource capability set. These are treated as read operations.